### PR TITLE
chore(examples): update registry org in example

### DIFF
--- a/examples/buckets/porter.yaml
+++ b/examples/buckets/porter.yaml
@@ -1,8 +1,7 @@
-name: porter-aws-bucket
+name: aws-bucket
 version: 0.1.0
 description: "An example Porter AWS bundle that plays with buckets"
-invocationImage: deislabs/porter-aws-bucket-installer:latest
-tag: deislabs/porter-aws-bucket:latest
+tag: getporter/aws-bucket
 
 mixins:
   - aws


### PR DESCRIPTION
* updates registry org in example as part of rm-ing `deislabs` strings in favor of the `getporter` org  (these were the only instances of `deislabs` found)