### PR TITLE
update(aws-cli): use latest install instructions for aws-cli v2

### DIFF
--- a/pkg/aws/build.go
+++ b/pkg/aws/build.go
@@ -6,10 +6,10 @@ import "fmt"
 // for an invocation image using this mixin
 func (m *Mixin) Build() error {
 	// TODO: This gets whatever the latest version of the cli is, there isn't a way for us to say what version we are using
-	fmt.Fprintln(m.Out, `RUN apt-get update && apt-get install -y curl unzip python less groff`)
-	fmt.Fprintln(m.Out, `RUN curl "https://s3.amazonaws.com/aws-cli/awscli-bundle.zip" -o "/tmp/awscli-bundle.zip"`)
-	fmt.Fprintln(m.Out, `RUN unzip /tmp/awscli-bundle.zip -d /tmp`)
-	fmt.Fprintln(m.Out, `RUN /tmp/awscli-bundle/install -i /usr/local/aws -b /usr/local/bin/aws`)
-	fmt.Fprintln(m.Out, `RUN rm -fr /tmp/awscli-bundle.zip /tmp/awscli-bundle`)
+	fmt.Fprintln(m.Out, `RUN apt-get update && apt-get install -y curl unzip glibc less groff`)
+	fmt.Fprintln(m.Out, `RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"`)
+	fmt.Fprintln(m.Out, `RUN unzip awscliv2.zip`)
+	fmt.Fprintln(m.Out, `RUN ./aws/install`)
+	fmt.Fprintln(m.Out, `RUN rm -fr awscliv2.zip ./aws`)
 	return nil
 }

--- a/pkg/aws/build.go
+++ b/pkg/aws/build.go
@@ -6,7 +6,7 @@ import "fmt"
 // for an invocation image using this mixin
 func (m *Mixin) Build() error {
 	// TODO: This gets whatever the latest version of the cli is, there isn't a way for us to say what version we are using
-	fmt.Fprintln(m.Out, `RUN apt-get update && apt-get install -y curl unzip glibc less groff`)
+	fmt.Fprintln(m.Out, `RUN apt-get update && apt-get install -y --no-install-recommends curl unzip libc6 less groff`)
 	fmt.Fprintln(m.Out, `RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"`)
 	fmt.Fprintln(m.Out, `RUN unzip awscliv2.zip`)
 	fmt.Fprintln(m.Out, `RUN ./aws/install`)

--- a/pkg/aws/build_test.go
+++ b/pkg/aws/build_test.go
@@ -1,24 +1,25 @@
 package aws
 
 import (
+	"testing"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"testing"
 )
 
 func TestMixin_Build(t *testing.T) {
 	m := NewTestMixin(t)
 
-	err  := m.Build()
+	err := m.Build()
 	require.NoError(t, err, "Build failed")
 
 	gotOutput := m.TestContext.GetOutput()
 
-	wantOutput := `RUN apt-get update && apt-get install -y curl unzip python less groff
-RUN curl "https://s3.amazonaws.com/aws-cli/awscli-bundle.zip" -o "/tmp/awscli-bundle.zip"
-RUN unzip /tmp/awscli-bundle.zip -d /tmp
-RUN /tmp/awscli-bundle/install -i /usr/local/aws -b /usr/local/bin/aws
-RUN rm -fr /tmp/awscli-bundle.zip /tmp/awscli-bundle
+	wantOutput := `RUN apt-get update && apt-get install -y curl unzip glibc less groff
+RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"
+RUN unzip awscliv2.zip
+RUN ./aws/install
+RUN rm -fr awscliv2.zip ./aws
 `
 
 	assert.Equal(t, wantOutput, gotOutput)

--- a/pkg/aws/build_test.go
+++ b/pkg/aws/build_test.go
@@ -15,7 +15,7 @@ func TestMixin_Build(t *testing.T) {
 
 	gotOutput := m.TestContext.GetOutput()
 
-	wantOutput := `RUN apt-get update && apt-get install -y curl unzip glibc less groff
+	wantOutput := `RUN apt-get update && apt-get install -y --no-install-recommends curl unzip libc6 less groff
 RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"
 RUN unzip awscliv2.zip
 RUN ./aws/install


### PR DESCRIPTION
# Problem

Python 2 has ceased to get updates since Jan 2020. Python 2.7 has ceased to be supported by the [AWS CLI as of July 15, 2021](https://aws.amazon.com/blogs/developer/announcing-end-of-support-for-python-2-7-in-aws-sdk-for-python-and-aws-cli-v1/).

The Porter AWS mixin is downloading and installing the AWS CLI v1 to the Docker installer image as well as using `apt-get python` which defaults to installing `python 2.7` causing the following error when trying to run `porter build` if the AWS mixin is included in the image (which it was by default pre-1.0):
```
Unsupported Python version detected: Python 2.7
To continue using this installer you must use Python 3.6 or later.
For more information see the following blog post: https://aws.amazon.com/blogs/developer/announcing-end-of-support-for-python-2-7-in-aws-sdk-for-python-and-aws-cli-v1/
```

# Solution

Update the AWS mixing build to install using the [latest AWS CLI v2 instructions](https://docs.aws.amazon.com/cli/latest/userguide/install-cliv2-linux.html) which the installer and the cli tool no longer have a specific dependency on python.

## FYI 

Because of the `gopls` in VS Code I couldn't save the `build.test.go` file without it moving the `"testing"` import line.
