### PR TITLE
feat(build.go): update aws installation to use host arch

### DIFF
--- a/pkg/aws/build.go
+++ b/pkg/aws/build.go
@@ -7,7 +7,7 @@ import "fmt"
 func (m *Mixin) Build() error {
 	// TODO: This gets whatever the latest version of the cli is, there isn't a way for us to say what version we are using
 	fmt.Fprintln(m.Out, `RUN apt-get update && apt-get install -y --no-install-recommends curl unzip libc6 less groff`)
-	fmt.Fprintln(m.Out, `RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"`)
+	fmt.Fprintln(m.Out, `RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-$(uname -m).zip" -o "awscliv2.zip"`)
 	fmt.Fprintln(m.Out, `RUN unzip awscliv2.zip`)
 	fmt.Fprintln(m.Out, `RUN ./aws/install`)
 	fmt.Fprintln(m.Out, `RUN rm -fr awscliv2.zip ./aws`)

--- a/pkg/aws/build_test.go
+++ b/pkg/aws/build_test.go
@@ -16,7 +16,7 @@ func TestMixin_Build(t *testing.T) {
 	gotOutput := m.TestContext.GetOutput()
 
 	wantOutput := `RUN apt-get update && apt-get install -y --no-install-recommends curl unzip libc6 less groff
-RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"
+RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-$(uname -m).zip" -o "awscliv2.zip"
 RUN unzip awscliv2.zip
 RUN ./aws/install
 RUN rm -fr awscliv2.zip ./aws


### PR DESCRIPTION
* Add support for host arch injection in the aws cli installation instructions

Tested (via building a bundle w/ this mixin) on an x86_64 and M1/arm64 Mac