### PR TITLE
Update example to v1 format

### DIFF
--- a/examples/buckets/porter.yaml
+++ b/examples/buckets/porter.yaml
@@ -1,7 +1,8 @@
+schemaVersion: 1.0.0-alpha.1
 name: aws-bucket
-version: 0.1.0
+version: 0.2.0
 description: "An example Porter AWS bundle that plays with buckets"
-tag: getporter/aws-bucket
+registry: ghcr.io/getporter
 
 mixins:
   - aws


### PR DESCRIPTION
Tested with:
```
porter install --credential-set aws
```
against porter v1.0.0-beta.2