### PR TITLE
Add user agent to AWS CLI requests

### DIFF
--- a/pkg/aws/aws.go
+++ b/pkg/aws/aws.go
@@ -11,8 +11,10 @@ type Mixin struct {
 
 // New aws mixin client, initialized with useful defaults.
 func New() (*Mixin, error) {
-	return &Mixin{
+	m := &Mixin{
 		Context: context.New(),
-	}, nil
+	}
+	m.SetUserAgent()
 
+	return m, nil
 }

--- a/pkg/aws/config.go
+++ b/pkg/aws/config.go
@@ -1,0 +1,24 @@
+package aws
+
+import (
+	"strings"
+
+	"get.porter.sh/porter/pkg"
+)
+
+const AWS_EXECUTION_ENV = "AWS_EXECUTION_ENV"
+
+func (m *Mixin) SetUserAgent() {
+	value := []string{pkg.UserAgent(), m.UserAgent()}
+
+	if agentStr, ok := m.LookupEnv(AWS_EXECUTION_ENV); ok {
+		value = append(value, agentStr)
+	}
+
+	m.Setenv(AWS_EXECUTION_ENV, strings.Join(value, " "))
+}
+
+func (m *Mixin) UserAgent() string {
+	v := m.Version()
+	return "getporter/" + v.Name + "/" + v.Version
+}

--- a/pkg/aws/config_test.go
+++ b/pkg/aws/config_test.go
@@ -1,0 +1,19 @@
+package aws
+
+import (
+	"testing"
+
+	"get.porter.sh/mixin/aws/pkg"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSetUserAgent(t *testing.T) {
+	pkg.Commit = "abc123"
+	pkg.Version = "v1.2.3"
+
+	m := NewTestMixin(t)
+	m.SetUserAgent()
+
+	expected := "getporter/aws/" + pkg.Version
+	require.Contains(t, m.Getenv(AWS_EXECUTION_ENV), expected)
+}

--- a/pkg/aws/version.go
+++ b/pkg/aws/version.go
@@ -8,7 +8,11 @@ import (
 )
 
 func (m *Mixin) PrintVersion(opts version.Options) error {
-	metadata := mixin.Metadata{
+	return version.PrintVersion(m.Context, opts, m.Version())
+}
+
+func (m *Mixin) Version() mixin.Metadata {
+	return mixin.Metadata{
 		Name: "aws",
 		VersionInfo: pkgmgmt.VersionInfo{
 			Version: pkg.Version,
@@ -16,5 +20,4 @@ func (m *Mixin) PrintVersion(opts version.Options) error {
 			Author:  "Porter Authors",
 		},
 	}
-	return version.PrintVersion(m.Context, opts, metadata)
 }


### PR DESCRIPTION
Setting the user agent for the AWS CLI helps provide more context in AWS CloudTrail entries about the API calls made by the Porter AWS mixin, especially where Porter might be using the same credentials used by other tools.

Example CloudTrail entry snippet for an S3 CreateBucket API call using the aws-bucket example, showing the Porter user agent:
```
{
    "eventVersion": "1.08",
    "eventTime": "2022-09-07T15:37:18Z",
    "eventSource": "s3.amazonaws.com",
    "eventName": "CreateBucket",
    "awsRegion": "us-east-1",
    "userAgent": "[aws-cli/2.7.29 Python/3.9.11 Linux/5.15.0-46-generic exec-env/getporter/porter getporter/aws/v0.0.0 exe/x86_64.debian.9 prompt/off command/s3api.create-bucket]",
```
